### PR TITLE
Update cordova return status code to OK from ERROR and convert the us…

### DIFF
--- a/plugin/src/ios/CDVMParticle.m
+++ b/plugin/src/ios/CDVMParticle.m
@@ -127,7 +127,7 @@
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:cordovaError];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             } else {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:apiResult.user.userId.doubleValue];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:apiResult.user.userId.stringValue];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }
         }];
@@ -155,7 +155,7 @@
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:cordovaError];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             } else {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:apiResult.user.userId.doubleValue];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:apiResult.user.userId.stringValue];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }
         }];
@@ -183,7 +183,7 @@
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:cordovaError];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             } else {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:apiResult.user.userId.doubleValue];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:apiResult.user.userId.stringValue];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }
         }];
@@ -211,7 +211,7 @@
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:cordovaError];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             } else {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:apiResult.user.userId.doubleValue];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:apiResult.user.userId.stringValue];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }
         }];
@@ -220,7 +220,7 @@
 
 - (void)getCurrentUser:(CDVInvokedUrlCommand*)command {
     [self.commandDelegate runInBackground:^{
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDouble:[[[MParticle sharedInstance] identity] currentUser].userId.doubleValue];
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[[MParticle sharedInstance] identity] currentUser].userId.stringValue];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
@@ -231,7 +231,7 @@
         
         MParticleUser *selectedUser = [[[MParticle sharedInstance] identity] getUser:userId];
         
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[selectedUser userIdentities]];
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[selectedUser userIdentities]];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }


### PR DESCRIPTION
For getCurrentUser and getUserIdentities methods, the return status code is CDVCommandStatus_ERROR  but it should be CDVCommandStatus_OK. 

And, iOS returns the userId as a big number that Javascript cannot handle since Javascript only supports 53 bit. (ex  iOS: 4165214795582912512 -> javascript: 4165214795582912500). So, it needs to return the userId as a string like [how Android returns](https://github.com/mParticle/cordova-plugin-mparticle/blob/master/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java#L306).  
