### PR TITLE
fix: update Android usage of info -> customAttributes

### DIFF
--- a/plugin/src/android/build.gradle
+++ b/plugin/src/android/build.gradle
@@ -20,11 +20,11 @@ repositories {
 
 dependencies {
     compileOnly("org.apache.cordova:framework:10.1.2")
-    compileOnly("com.mparticle:android-core:5.38.1")
+    compileOnly("com.mparticle:android-core:+")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20220320")
     testImplementation("org.mockito:mockito-core:4.5.1")
     testImplementation("org.apache.cordova:framework:10.1.2")
-    testImplementation("com.mparticle:android-core:5.38.1")
+    testImplementation("com.mparticle:android-core:+")
 }

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
@@ -107,7 +107,7 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
         MParticle.EventType eventType = ConvertEventType(type);
 
         MPEvent event = new MPEvent.Builder(name, eventType)
-                .info(attributes)
+                .customAttributes(attributes)
                 .build();
 
         MParticle.getInstance().logEvent(event);
@@ -425,7 +425,7 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
             }
             if (map.has("info")) {
                 Map<String, String> customInfo = ConvertStringMap(map.getJSONObject("info"));
-                builder.info(customInfo);
+                builder.customAttributes(customInfo);
             }
             if (map.has("customFlags")) {
                 Map<String, String> customFlags = ConvertStringMap(map.getJSONObject("customFlags"));

--- a/plugin/src/android/src/test/java/com/mparticle/cordova/MParticleCordovaTests.java
+++ b/plugin/src/android/src/test/java/com/mparticle/cordova/MParticleCordovaTests.java
@@ -89,7 +89,7 @@ public class MParticleCordovaTests {
         attributes.put("Test key", "Test value");
         info.put("Test key", "Test value");
         MPEvent event = new MPEvent.Builder(eventName, eventType)
-                .info(attributes)
+                .customAttributes(attributes)
                 .build();
 
         MParticleCordovaPlugin plugin = new MParticleCordovaPlugin();


### PR DESCRIPTION
## Summary

Replace usages of `BaseEvent`s now removed `info()` method

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4061