### PR TITLE
fix: Setting GDPR Consents on iOS

### DIFF
--- a/plugin/src/ios/CDVMParticle.m
+++ b/plugin/src/ios/CDVMParticle.m
@@ -72,7 +72,7 @@
 - (void)addGDPRConsentState:(CDVInvokedUrlCommand*)command {
     [self.commandDelegate runInBackground:^{
         NSMutableDictionary *serializedConsent = [command.arguments objectAtIndex:0];
-        NSString *purpose = [command.arguments objectAtIndex:0];
+        NSString *purpose = [command.arguments objectAtIndex:1];
         
         MPGDPRConsent *consent = [CDVMParticle MPGDPRConsent:serializedConsent];
         MPConsentState *consentState = [[MParticle sharedInstance].identity.currentUser.consentState copy];


### PR DESCRIPTION
## Summary
 - 'addGDPR' was failing in iOS but not Android. On investigation the wrong value was being used for the purpose key.

 ## Testing Plan
Tested locally 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5055)
