### PR TITLE
Feat/upgrade apple sdk v9

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,11 +42,11 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v6.0.2
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
       - name: Install NPM
         uses: actions/setup-node@v6
       - name: NPM Build

--- a/Kits/Rokt/plugin.xml
+++ b/Kits/Rokt/plugin.xml
@@ -13,7 +13,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="mParticle-Rokt" spec="8.3.0" />
+                <pod name="mParticle-Rokt" spec="~> 9.0" />
             </pods>
         </podspec>
     </platform>

--- a/example/config.xml
+++ b/example/config.xml
@@ -20,8 +20,8 @@
         <allow-intent href="market:*" />
     </platform>
     <platform name="ios">
-        <preference name="deployment-target" value="12.0" />
-        <preference name="pods_ios_min_version" value="12.0" />
+        <preference name="deployment-target" value="16.0" />
+        <preference name="pods_ios_min_version" value="16.0" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
     </platform>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -12,7 +12,7 @@
                 <param name="android-package" value="com.mparticle.cordova.MParticleCordovaPlugin"/>
             </feature>
         </config-file>
-        <source-file src="src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java" target-dir="src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java" />
+        <source-file src="src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java" target-dir="src/com/mparticle/cordova" />
         <framework src="com.mparticle:android-core:5.71.0"/>
     </platform>
     <platform name="ios">
@@ -27,7 +27,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="mParticle-Apple-SDK" spec="8.37.1" />
+                <pod name="mParticle-Apple-SDK" spec="~> 9.0" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/src/ios/CDVMParticle.m
+++ b/plugin/src/ios/CDVMParticle.m
@@ -8,6 +8,10 @@
 
 @implementation CDVMParticle
 
+- (void)pluginInitialize {
+    [MParticle _setWrapperSdk_internal:MPWrapperSdkCordova version:@""];
+}
+
 - (void)logEvent:(CDVInvokedUrlCommand*)command {
     [self.commandDelegate runInBackground:^{
         NSString *eventName = [command.arguments objectAtIndex:0];
@@ -362,24 +366,22 @@
 }
 
 - (void)selectPlacements:(CDVInvokedUrlCommand*)command {
-    NSString *identifier = [command.arguments objectAtIndex:0];
-    NSDictionary *attributes = [command.arguments objectAtIndex:1];
-    NSDictionary *configDict = [command.arguments objectAtIndex:2];
+    [self.commandDelegate runInBackground:^{
+        NSString *identifier = [command.arguments objectAtIndex:0];
+        NSDictionary *attributes = [command.arguments objectAtIndex:1];
+        NSDictionary *configDict = [command.arguments objectAtIndex:2];
 
-    RoktConfig *config = [self buildRoktConfigFromDict:configDict];
+        RoktConfig *config = [self buildRoktConfigFromDict:configDict];
 
-    [MParticle _setWrapperSdk_internal:MPWrapperSdkCordova version:@""];
-
-    dispatch_async(dispatch_get_main_queue(), ^{
         [[MParticle sharedInstance].rokt selectPlacements:identifier
                                              attributes:attributes
                                           embeddedViews:nil
                                                 config:config
                                                onEvent:nil];
-    });
 
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
 typedef NS_ENUM(NSUInteger, MPCDVCommerceEventAction) {

--- a/plugin/src/ios/CDVMParticle.m
+++ b/plugin/src/ios/CDVMParticle.m
@@ -338,7 +338,7 @@
     BOOL isConfigEmpty = YES;
 
     NSString *colorModeStr = configDict[@"colorMode"][@"value"];
-    if (colorModeStr && [colorModeStr isKindOfClass:[NSString class]]) {
+    if (colorModeStr) {
         isConfigEmpty = NO;
         if ([colorModeStr isEqualToString:@"LIGHT"]) {
             [builder colorMode:RoktColorModeLight];
@@ -350,7 +350,7 @@
     }
 
     NSDictionary *cacheConfigDict = configDict[@"cacheConfig"];
-    if (cacheConfigDict && [cacheConfigDict isKindOfClass:[NSDictionary class]]) {
+    if (cacheConfigDict) {
         isConfigEmpty = NO;
         NSNumber *cacheDuration = cacheConfigDict[@"cacheDurationInSeconds"];
         if (!cacheDuration) {

--- a/plugin/src/ios/CDVMParticle.m
+++ b/plugin/src/ios/CDVMParticle.m
@@ -1,5 +1,7 @@
 #import <Cordova/CDV.h>
 @import mParticle_Apple_SDK;
+@import mParticle_Apple_SDK_ObjC;
+@import RoktContracts;
 
 @interface CDVMParticle : CDVPlugin
 @end
@@ -323,38 +325,61 @@
     }];
 }
 
-- (void)selectPlacements:(CDVInvokedUrlCommand*)command {
-    [self.commandDelegate runInBackground:^{
-        NSString *identifier = [command.arguments objectAtIndex:0];
-        NSDictionary *attributes = [command.arguments objectAtIndex:1];
-        NSDictionary *configDict = [command.arguments objectAtIndex:2];
+- (RoktConfig *)buildRoktConfigFromDict:(NSDictionary *)configDict {
+    if (configDict == nil || configDict.count == 0) {
+        return nil;
+    }
 
-        MPRoktConfig *config = [[MPRoktConfig alloc] init];
+    RoktConfigBuilder *builder = [[RoktConfigBuilder alloc] init];
+    BOOL isConfigEmpty = YES;
 
-        NSString *colorModeStr = configDict[@"colorMode"][@"value"];
+    NSString *colorModeStr = configDict[@"colorMode"][@"value"];
+    if (colorModeStr && [colorModeStr isKindOfClass:[NSString class]]) {
+        isConfigEmpty = NO;
         if ([colorModeStr isEqualToString:@"LIGHT"]) {
-            config.colorMode = MPColorModeLight;
+            [builder colorMode:RoktColorModeLight];
         } else if ([colorModeStr isEqualToString:@"DARK"]) {
-            config.colorMode = MPColorModeDark;
+            [builder colorMode:RoktColorModeDark];
         } else {
-            config.colorMode = MPColorModeSystem;
+            [builder colorMode:RoktColorModeSystem];
         }
+    }
 
-        NSDictionary *cacheConfig = configDict[@"cacheConfig"];
-        if (cacheConfig) {
-            config.cacheDuration = @([cacheConfig[@"cacheDurationInSeconds"] longLongValue]);
-            config.cacheAttributes = cacheConfig[@"cacheAttributes"];
+    NSDictionary *cacheConfigDict = configDict[@"cacheConfig"];
+    if (cacheConfigDict && [cacheConfigDict isKindOfClass:[NSDictionary class]]) {
+        isConfigEmpty = NO;
+        NSNumber *cacheDuration = cacheConfigDict[@"cacheDurationInSeconds"];
+        if (!cacheDuration) {
+            cacheDuration = @0;
         }
+        NSDictionary *cacheAttrs = cacheConfigDict[@"cacheAttributes"];
+        RoktCacheConfig *cacheConfig = [[RoktCacheConfig alloc] initWithCacheDuration:[cacheDuration doubleValue]
+                                                                      cacheAttributes:cacheAttrs ?: @{}];
+        [builder cacheConfig:cacheConfig];
+    }
 
+    return isConfigEmpty ? nil : [builder build];
+}
+
+- (void)selectPlacements:(CDVInvokedUrlCommand*)command {
+    NSString *identifier = [command.arguments objectAtIndex:0];
+    NSDictionary *attributes = [command.arguments objectAtIndex:1];
+    NSDictionary *configDict = [command.arguments objectAtIndex:2];
+
+    RoktConfig *config = [self buildRoktConfigFromDict:configDict];
+
+    [MParticle _setWrapperSdk_internal:MPWrapperSdkCordova version:@""];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
         [[MParticle sharedInstance].rokt selectPlacements:identifier
                                              attributes:attributes
                                           embeddedViews:nil
                                                 config:config
-                                             callbacks:nil];
-        
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+                                               onEvent:nil];
+    });
+
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 typedef NS_ENUM(NSUInteger, MPCDVCommerceEventAction) {


### PR DESCRIPTION
## Summary
Upgrades the iOS mParticle Apple SDK and Rokt kit from v8 to v9.

  - **Pod versions**: `mParticle-Apple-SDK` `8.37.1` → `~> 9.0`, `mParticle-Rokt` `8.3.0` → `~> 9.0`
  - **iOS deployment target**: `12.0` → `16.0` (v9 requires 15.6+)
  - **Android fix**: Corrected `target-dir` in plugin.xml that caused nested directory errors on `cordova platform add android`
  - **CDVMParticle.m**: Migrated to v9 module imports (`mParticle_Apple_SDK`, `mParticle_Apple_SDK_ObjC`, `RoktContracts`), updated Rokt config to use `RoktConfigBuilder` pattern, set Cordova wrapper SDK type in
  `pluginInitialize`

  > **Key finding during migration:** the Rokt Widget SDK v9 requires `RoktConfig` to be `nil` when no meaningful config values are set — passing a default-built config causes placements to silently return empty. The
  `buildRoktConfigFromDict:` helper mirrors the React Native SDK's approach of returning `nil` for empty configs.

  ## Test plan

  - [x] Clean build and run on iOS simulator
  - [x] mParticle event logging verified
  - [x] Rokt overlay placement renders correctly