### PR TITLE
docs: add CNAME initialization examples for iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- README examples for configuring a custom CNAME endpoint on iOS (`MPNetworkOptions.customBaseURL`) and Android (`NetworkOptions.withNetworkOptions`).
+
 ## [3.0.1] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 }
 ```
 
+Optional: if your team uses a custom CNAME endpoint, configure `MPNetworkOptions` separately:
+
+```swift
+let networkOptions = MPNetworkOptions()
+networkOptions.customBaseURL = URL(string: "https://rkt.example.com")
+mParticleOptions.networkOptions = networkOptions
+```
+
+```objective-c
+MPNetworkOptions *networkOptions = [MPNetworkOptions new];
+networkOptions.customBaseURL = [NSURL URLWithString:@"https://rkt.example.com"];
+mParticleOptions.networkOptions = networkOptions;
+```
+
 Please see [Identity](http://docs.mparticle.com/developers/sdk/ios/identity/) for more information on supplying an `MPIdentityApiRequest` object during SDK initialization.
 
 
@@ -126,6 +140,26 @@ class MyApplication : Application() {
         MParticle.start(options)
     }
 }
+```
+
+Optional: if your team uses a custom CNAME endpoint, configure `NetworkOptions` separately:
+
+```java
+import com.mparticle.networking.NetworkOptions;
+
+MParticleOptions options = MParticleOptions.builder(this)
+    .credentials("REPLACE ME WITH KEY", "REPLACE ME WITH SECRET")
+    .networkOptions(NetworkOptions.withNetworkOptions("https://rkt.example.com"))
+    .build();
+```
+
+```kotlin
+import com.mparticle.networking.NetworkOptions
+
+val options = MParticleOptions.builder(this)
+    .credentials("REPLACE ME WITH KEY", "REPLACE ME WITH SECRET")
+    .networkOptions(NetworkOptions.withNetworkOptions("https://rkt.example.com"))
+    .build()
 ```
 
 > **Warning:** It's generally not a good idea to log events in your `Application.onCreate()`. Android may instantiate your `Application` class for a lot of reasons, in the background, while the user isn't even using their device.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 }
 ```
 
-Optional: if your team uses a custom CNAME endpoint, configure `MPNetworkOptions` separately:
+Routing the Rokt SDK+ through your own domain reduces the risk of ad blockers and browsers from blocking ads or data. You can configure this with `MPNetworkOptions`:
 
 ```swift
 let networkOptions = MPNetworkOptions()
@@ -128,7 +128,7 @@ class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         val options: MParticleOptions = MParticleOptions.builder(this)
-            .credentials("REPLACE ME WITH KEY", "REPLACE ME WITH SECRET")
+            .credentials("REPLACE_ME_WITH_KEY", "REPLACE_ME_WITH_SECRET")
             .logLevel(MParticle.LogLevel.VERBOSE)
             .identify(identifyRequest)
             .identifyTask(
@@ -142,13 +142,13 @@ class MyApplication : Application() {
 }
 ```
 
-Optional: if your team uses a custom CNAME endpoint, configure `NetworkOptions` separately:
+Routing the Rokt SDK+ through your own domain reduces the risk of ad blockers and browsers from blocking ads or data. You can configure this with `NetworkOptions`:
 
 ```java
 import com.mparticle.networking.NetworkOptions;
 
 MParticleOptions options = MParticleOptions.builder(this)
-    .credentials("REPLACE ME WITH KEY", "REPLACE ME WITH SECRET")
+    .credentials("REPLACE_ME_WITH_KEY", "REPLACE_ME_WITH_SECRET")
     .networkOptions(NetworkOptions.withNetworkOptions("https://rkt.example.com"))
     .build();
 ```
@@ -157,7 +157,7 @@ MParticleOptions options = MParticleOptions.builder(this)
 import com.mparticle.networking.NetworkOptions
 
 val options = MParticleOptions.builder(this)
-    .credentials("REPLACE ME WITH KEY", "REPLACE ME WITH SECRET")
+    .credentials("REPLACE_ME_WITH_KEY", "REPLACE_ME_WITH_SECRET")
     .networkOptions(NetworkOptions.withNetworkOptions("https://rkt.example.com"))
     .build()
 ```


### PR DESCRIPTION
## Background

mParticle [Flutter PR #73](https://github.com/mParticle/mparticle-flutter-sdk/pull/73) added README examples for configuring a custom CNAME endpoint without any new Dart API — Flutter consumers initialise the mParticle SDK natively from their `AppDelegate` / `Application` class and wire `MPNetworkOptions.customBaseURL` / `NetworkOptions.withNetworkOptions` directly. React Native takes the same approach (no runtime JS bridge; only an Expo config plugin for build-time codegen). Cordova consumers initialise the same way, so a docs-only change matches.

## What's changed

- README iOS section: `MPNetworkOptions.customBaseURL` snippet (Swift + Objective-C) inserted after the standard init example.
- README Android section: `NetworkOptions.withNetworkOptions` snippet (Java + Kotlin) inserted after the standard init example.
- `CHANGELOG.md` `[Unreleased]` entry under **Added**.

No JS API, no native bridge changes, no dependency bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)