### PR TITLE
fix: set iOS wrapper SDK version and cover RoktPaymentExtension in release flow

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -68,10 +68,20 @@ jobs:
         run: |
           npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version
 
+      - name: Update Rokt Payment Extension package.json
+        working-directory: Kits/RoktPaymentExtension
+        run: |
+          npm version ${{ steps.bump-version.outputs.new_version }} --no-git-tag-version
+
       - name: Update plugin.xml versions
         run: |
           sed -i '' "s/version=\"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/version=\"${{ steps.bump-version.outputs.new_version }}\"/" plugin/plugin.xml
           sed -i '' "s/version=\"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/version=\"${{ steps.bump-version.outputs.new_version }}\"/" Kits/Rokt/plugin.xml
+          sed -i '' "s/version=\"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/version=\"${{ steps.bump-version.outputs.new_version }}\"/" Kits/RoktPaymentExtension/plugin.xml
+
+      - name: Update iOS wrapper SDK version
+        run: |
+          sed -i '' "s/_setWrapperSdk_internal:MPWrapperSdkCordova version:@\"[0-9.]*\"/_setWrapperSdk_internal:MPWrapperSdkCordova version:@\"${{ steps.bump-version.outputs.new_version }}\"/" plugin/src/ios/CDVMParticle.m
 
       - name: Publish Plugin to npm (dry-run)
         working-directory: plugin
@@ -79,6 +89,10 @@ jobs:
 
       - name: Publish Rokt Kit to npm (dry-run)
         working-directory: Kits/Rokt
+        run: npm publish --dry-run
+
+      - name: Publish Rokt Payment Extension to npm (dry-run)
+        working-directory: Kits/RoktPaymentExtension
         run: npm publish --dry-run
 
       - name: Update changelog
@@ -108,14 +122,17 @@ jobs:
           body: |
             Preparing for release ${{ steps.bump-version.outputs.new_version }}
 
-            There should be 6 files that have been updated:
+            There should be 9 files that have been updated:
             - plugin/package.json
             - plugin/plugin.xml
+            - plugin/src/ios/CDVMParticle.m
             - Kits/Rokt/package.json
             - Kits/Rokt/plugin.xml
+            - Kits/RoktPaymentExtension/package.json
+            - Kits/RoktPaymentExtension/plugin.xml
             - CHANGELOG.md
             - VERSION
 
-            Additionally a dry-run publish was successfully run for the plugin and Rokt kit.
+            Additionally a dry-run publish was successfully run for the plugin, Rokt kit, and Rokt payment extension.
           labels: |
             release

--- a/Kits/RoktPaymentExtension/package.json
+++ b/Kits/RoktPaymentExtension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/cordova-rokt-payment-extension",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Adds Rokt payment extension support (Apple Pay, AfterPay/Clearpay, PayPal via Stripe) to your Cordova project",
   "homepage": "https://www.mparticle.com",
   "repository": {

--- a/Kits/RoktPaymentExtension/plugin.xml
+++ b/Kits/RoktPaymentExtension/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
            id="@mparticle/cordova-rokt-payment-extension"
-           version="3.0.0">
+           version="3.0.1">
     <name>MParticle Rokt Payment Extension Kit</name>
     <description>Adds Rokt payment extension support (Apple Pay, AfterPay/Clearpay, PayPal via Stripe) to your Cordova project</description>
     <platform name="ios">

--- a/plugin/src/ios/CDVMParticle.m
+++ b/plugin/src/ios/CDVMParticle.m
@@ -9,7 +9,7 @@
 @implementation CDVMParticle
 
 - (void)pluginInitialize {
-    [MParticle _setWrapperSdk_internal:MPWrapperSdkCordova version:@""];
+    [MParticle _setWrapperSdk_internal:MPWrapperSdkCordova version:@"3.0.1"];
 }
 
 - (void)logEvent:(CDVInvokedUrlCommand*)command {


### PR DESCRIPTION
## Problem
The release workflow (`draft-release-publish.yml`) only versioned and published
`plugin` + `Kits/Rokt`, leaving two gaps surfaced while reviewing #84:

1. **iOS wrapper version was empty.** `CDVMParticle.m` called
   `_setWrapperSdk_internal:MPWrapperSdkCordova version:@""`, and nothing in the
   release flow ever set it — so mParticle received no Cordova wrapper version.
2. **`Kits/RoktPaymentExtension` was unmanaged.** The new payment-extension kit
   was never version-bumped or published by the release flow, and had already
   drifted to `3.0.0` while the rest of the repo is `3.0.1`.

## Fix
- Seed the wrapper version (`@"3.0.1"`) and bump it from the release workflow
  alongside `plugin.xml` (new "Update iOS wrapper SDK version" step).
- Add version-bump, `plugin.xml` sed, and dry-run-publish steps for
  `Kits/RoktPaymentExtension`, mirroring the Rokt kit; align it to `3.0.1`.
- Update the prepared-release PR body to list all 9 affected files.

## Verification
- `actionlint` clean.
- Simulated the new `sed` bumps to `4.0.0`: wrapper line and payment-extension
  `plugin.xml` plugin version update correctly; XML declaration untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
