### PR TITLE
fix(release): unblock npm publish — remove broken kit install, add payment ext

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -52,12 +52,12 @@ jobs:
         working-directory: plugin
         run: npm publish --access public
 
-      - name: Install Rokt Kit dependencies
-        working-directory: Kits/Rokt
-        run: npm ci
-
       - name: Publish Rokt Kit to npm
         working-directory: Kits/Rokt
+        run: npm publish --access public
+
+      - name: Publish Rokt Payment Extension to npm
+        working-directory: Kits/RoktPaymentExtension
         run: npm publish --access public
 
       - uses: ffurrer2/extract-release-notes@273da39a24fb7db106a35526c8162815faffd31d # v3.1.0


### PR DESCRIPTION
## Context
The 4.0.0 release ([run](https://github.com/mParticle/cordova-plugin-mparticle/actions/runs/27424062209)) **partially published**: `@mparticle/cordova-sdk@4.0.0` reached npm, then the workflow **failed at "Install Rokt Kit dependencies"**. The Rokt kit never published, and no git tag or GitHub release was created.

## Root cause
`release-from-main.yml` ran `npm ci` in `Kits/Rokt`. `npm ci` **requires** a `package-lock.json`. That lock file was intentionally removed (the kits are dependency-less and carry no lock), so `npm ci` failed with `EUSAGE`.

## Changes
1. **Remove the Rokt kit install step entirely.** The kits have no dependencies and no lifecycle scripts, so `npm publish` packs and uploads on its own — there is nothing to install. (The `npm ci` was cargo-culted from the plugin's step, where it is needed to run tests + build.)
2. **Add the `Kits/RoktPaymentExtension` publish step.** It's new in 4.0.0 with `publishConfig`, but the workflow had no step for it, so it was never published to npm.

## Recovery plan
We will **not** re-run 4.0.0. Roll forward to **4.0.1** through the normal flow:
1. Merge this PR (workflow-only — does not touch `VERSION`, so it won't trigger a release).
2. Dispatch `draft-release-publish.yml` with a **patch** bump → opens the 4.0.1 release PR.
3. Merge that PR → `VERSION` changes → `release-from-main.yml` publishes all three packages at 4.0.1 and cuts tag `4.0.1` + the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)