### PR TITLE
feat: Update to Latest Version of SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped Android native dependencies to `com.mparticle:android-core:6.0.0` and `com.mparticle:android-rokt-kit:6.0.0`.
 - Bumped iOS pod specs to `mParticle-Apple-SDK ~> 9.3` and `mParticle-Rokt ~> 9.3`.
 - Migrated the Android Rokt bridge for SDK 6.0.0: Rokt moved out of `android-core` into `android-rokt-kit` and `com.rokt.roktsdk` contracts (`MParticleRoktKt.getRokt()`, `com.rokt.roktsdk.RoktEvent`, `com.rokt.roktsdk.RoktConfig`, etc.).
+- Android Rokt integration is now optional: the core plugin compiles against `android-rokt-kit` via `compileOnly` and guards Rokt APIs at runtime (`RoktKitAvailability`). Apps without `@mparticle/cordova-rokt-kit` build successfully; Rokt method calls return a clear error until the kit is installed.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `mparticle.Rokt.setSessionId(sessionId)` / `mparticle.Rokt.getSessionId(completion)` — bridged to `MPRokt.setSessionId:` / `-getSessionId` on iOS and `MParticle.getInstance().Rokt().setSessionId / .getSessionId` on Android. Useful for keeping the native and WebView legs of a flow on the same Rokt session.
-- `mparticle.Rokt.handleURLCallback(url, completion)` — bridged to `[MPRokt handleURLCallback:]` on iOS so the host AppDelegate can hand redirect-based payment callbacks (AfterPay, PayPal) back to the registered Rokt payment extension. Android is a logged no-op until the Android SDK ships the same hook.
+- `mparticle.Rokt.handleURLCallback(url, completion)` — bridged to `[MPRokt handleURLCallback:]` on iOS so the host AppDelegate can hand redirect-based payment callbacks (AfterPay, PayPal) back to the registered Rokt payment extension. Android is a silent no-op that resolves to `false`.
 - README examples for configuring a custom CNAME endpoint on iOS (`MPNetworkOptions.customBaseURL`) and Android (`NetworkOptions.withNetworkOptions`).
 
 ## [3.0.1] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped Android native dependencies to `com.mparticle:android-core:6.0.0` and `com.mparticle:android-rokt-kit:6.0.0`.
+- Bumped iOS pod specs to `mParticle-Apple-SDK ~> 9.3` and `mParticle-Rokt ~> 9.3`.
+- Migrated the Android Rokt bridge for SDK 6.0.0: Rokt moved out of `android-core` into `android-rokt-kit` and `com.rokt.roktsdk` contracts (`MParticleRoktKt.getRokt()`, `com.rokt.roktsdk.RoktEvent`, `com.rokt.roktsdk.RoktConfig`, etc.).
+
+### Added
+
+- Android support for `mparticle.Rokt.selectShoppableAds` and `mparticle.Rokt.purchaseFinalized` (previously logged no-ops on Android).
+
+### Fixed
+
+- Android Rokt event serialization updated for SDK 6.0.0 event types (`getIdentifier()` replaces `getPlacementId()`).
+
+### Notes
+
+- `mparticle.Rokt.handleURLCallback` remains iOS-only; Android SDK 6.0.0 does not yet expose an equivalent hook.
+- Device-level consent APIs in native SDK 9.3.1 / 6.0.0 are not yet exposed through the Cordova JS bridge.
+- `@mparticle/cordova-rokt-payment-extension` remains iOS-only (registers `RoktPaymentExtension` for Apple Pay / AfterPay / PayPal).
+
 ## [4.0.1] - 2026-06-12
 
 ## [4.0.0] - 2026-06-11

--- a/Kits/Rokt/README.md
+++ b/Kits/Rokt/README.md
@@ -6,7 +6,7 @@ Cordova plugin that adds mParticle Rokt kit native dependencies to your project.
 
 This plugin automatically adds the following native dependencies:
 
-- **Android**: `com.mparticle:android-rokt-kit:5.71.0`
-- **iOS**: `mParticle-Rokt` version `8.3.0`
+- **Android**: `com.mparticle:android-rokt-kit:6.0.0`
+- **iOS**: `mParticle-Rokt` version `~> 9.3`
 
-No additional configuration needed - just install the plugin and the dependencies will be added automatically when you build your project.
+No additional configuration needed — just install the plugin and the dependencies will be added automatically when you build your project.

--- a/Kits/Rokt/plugin.xml
+++ b/Kits/Rokt/plugin.xml
@@ -5,7 +5,7 @@
     <name>MParticle Rokt Kit</name>
     <description>Adds support for Rokt to your Cordova project</description>
     <platform name="android">
-        <framework src="com.mparticle:android-rokt-kit:5.79.1"/>
+        <framework src="com.mparticle:android-rokt-kit:6.0.0"/>
     </platform>
     <platform name="ios">
         <podspec>
@@ -13,7 +13,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="mParticle-Rokt" spec="~> 9.2" />
+                <pod name="mParticle-Rokt" spec="~> 9.3" />
             </pods>
         </podspec>
     </platform>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This release targets the following native SDKs:
 | iOS | `mParticle-Apple-SDK` | `~> 9.3` ([v9.3.1](https://github.com/mParticle/mparticle-apple-sdk/releases/tag/v9.3.1)) |
 | Android | `com.mparticle:android-core` | `6.0.0` ([release](https://github.com/mParticle/mparticle-android-sdk/releases/tag/6.0.0)) |
 
-When using Rokt, also install `@mparticle/cordova-rokt-kit`, which pins `mParticle-Rokt ~> 9.3` on iOS and `com.mparticle:android-rokt-kit:6.0.0` on Android.
+When using Rokt, also install `@mparticle/cordova-rokt-kit`, which pins `mParticle-Rokt ~> 9.3` on iOS and `com.mparticle:android-rokt-kit:6.0.0` on Android. On Android, the core plugin compiles against the Rokt kit via `compileOnly` and guards Rokt APIs at runtime — apps without the kit build successfully, and Rokt method calls return an error until the kit is installed.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ Cordova plugin for mParticle
 [![npm version](https://badge.fury.io/js/cordova-plugin-mparticle.svg)](https://badge.fury.io/js/cordova-plugin-mparticle)
 [![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](http://standardjs.com/)
 
+## Native SDK versions
+
+This release targets the following native SDKs:
+
+| Platform | Dependency | Version |
+| --- | --- | --- |
+| iOS | `mParticle-Apple-SDK` | `~> 9.3` ([v9.3.1](https://github.com/mParticle/mparticle-apple-sdk/releases/tag/v9.3.1)) |
+| Android | `com.mparticle:android-core` | `6.0.0` ([release](https://github.com/mParticle/mparticle-android-sdk/releases/tag/6.0.0)) |
+
+When using Rokt, also install `@mparticle/cordova-rokt-kit`, which pins `mParticle-Rokt ~> 9.3` on iOS and `com.mparticle:android-rokt-kit:6.0.0` on Android.
+
 # Installation
 
 ```bash
@@ -20,7 +31,7 @@ cordova plugin add @mparticle/cordova-sdk
 **Install the SDK** using CocoaPods:
 
 ```bash
-$ # Update your Podfile to depend on 'mParticle-Apple-SDK' version 9.2.0 or later
+$ # Update your Podfile to depend on 'mParticle-Apple-SDK' version 9.3.0 or later
 $ pod install
 ```
 
@@ -305,7 +316,7 @@ identity.modify(request, function (userId) => {
 Add the Rokt kit to your `config.xml`:
 
 ```xml
-<plugin name="@mparticle/cordova-rokt-kit" spec="~> 3.0" />
+<plugin name="@mparticle/cordova-rokt-kit" spec="~> 4.0" />
 ```
 
 ### Select Placements
@@ -379,7 +390,7 @@ Each event delivered to your callback is an object with an `event` discriminator
 | `OpenUrl` | `placementId`, `url` | Passthrough link requested. |
 | `CartItemInstantPurchase` | `placementId`, `cartItemId`, `catalogItemId`, `currency`, `description`, `linkedProductId`, `totalPrice`, `quantity`, `unitPrice` | Shoppable Ads purchase completed. |
 
-The following event types are **iOS only** (no Android equivalent in the underlying SDK):
+The following event types are **iOS only** (not yet emitted by the Android Rokt SDK):
 
 | Event | Fields |
 | --- | --- |
@@ -391,17 +402,19 @@ The following event types are **iOS only** (no Android equivalent in the underly
 
 ### Shoppable Ads
 
-Shoppable Ads enable post-purchase upsell offers with instant checkout (Apple Pay, AfterPay/Clearpay, PayPal via Stripe). Currently supported on **iOS only** — `selectShoppableAds` is a logged no-op on Android, matching the React Native and Flutter wrappers.
+Shoppable Ads enable post-purchase upsell offers with instant checkout (Apple Pay, AfterPay/Clearpay, PayPal via Stripe). `selectShoppableAds` and `purchaseFinalized` are supported on **both iOS and Android** when using `@mparticle/cordova-rokt-kit` with native SDK 6.0.0 / 9.3.x.
 
-#### 1. Add the payment extension kit
+Payment extension registration for Apple Pay / AfterPay / PayPal remains **iOS-only** via `@mparticle/cordova-rokt-payment-extension`. Register the extension natively on Android if your integration requires it.
+
+#### 1. Add the payment extension kit (iOS)
 
 ```xml
-<plugin name="@mparticle/cordova-rokt-payment-extension" spec="~> 3.0" />
+<plugin name="@mparticle/cordova-rokt-payment-extension" spec="~> 4.0" />
 ```
 
-This contributes the `RoktPaymentExtension` CocoaPod (`~> 2.0`) to your iOS target. There is no Android artefact.
+This contributes the `RoktPaymentExtension` CocoaPod (`~> 2.0`) to your iOS target. There is no Cordova artefact for Android payment extension registration.
 
-#### 2. Register the payment extension from your AppDelegate
+#### 2. Register the payment extension from your AppDelegate (iOS)
 
 `RoktPaymentExtension` is a pure-Swift class whose failable initialiser isn't `@objc`-exported, so ObjC AppDelegates need a small Swift shim. See [`example/platform_overrides/ios/RoktPaymentSetup.swift`](example/platform_overrides/ios/RoktPaymentSetup.swift) for the working example:
 
@@ -427,7 +440,7 @@ Then call from your AppDelegate after `startWithOptions:`:
 [RoktPaymentSetup registerPaymentExtensionWithMerchantId:@"merchant.com.yourapp.rokt"];
 ```
 
-The Rokt kit on mParticle Apple SDK 9.2 reads `stripePublishableKey` from kit configuration in the mParticle dashboard and forwards it to Rokt as `stripeKey` at registration time — the host only supplies the Apple Pay merchant identifier above.
+The Rokt kit on mParticle Apple SDK 9.3 reads `stripePublishableKey` from kit configuration in the mParticle dashboard and forwards it to Rokt as `stripeKey` at registration time — the host only supplies the Apple Pay merchant identifier above.
 
 #### 3. Display Shoppable Ads
 

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ mparticle.Rokt.handleURLCallback(urlString, function (handled) {
 });
 ```
 
-`handleURLCallback` is iOS-only; the Android bridge logs a warning and resolves to `false`.
+`handleURLCallback` is iOS-only; the Android bridge resolves to `false`.
 
 #### 5. Session continuity with WebViews (optional)
 

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -13,7 +13,7 @@
             </feature>
         </config-file>
         <source-file src="src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java" target-dir="src/com/mparticle/cordova" />
-        <framework src="com.mparticle:android-core:5.79.1"/>
+        <framework src="com.mparticle:android-core:6.0.0"/>
     </platform>
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
@@ -27,7 +27,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="mParticle-Apple-SDK" spec="~> 9.2" />
+                <pod name="mParticle-Apple-SDK" spec="~> 9.3" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -13,7 +13,11 @@
             </feature>
         </config-file>
         <source-file src="src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java" target-dir="src/com/mparticle/cordova" />
+        <source-file src="src/android/src/main/java/com/mparticle/cordova/RoktKitAvailability.java" target-dir="src/com/mparticle/cordova" />
+        <source-file src="src/android/src/main/java/com/mparticle/cordova/RoktPluginDelegate.java" target-dir="src/com/mparticle/cordova" />
+        <source-file src="src/android/src/main/java/com/mparticle/cordova/RoktBridge.java" target-dir="src/com/mparticle/cordova" />
         <framework src="com.mparticle:android-core:6.0.0"/>
+        <framework src="src/android/cordova.gradle" custom="true" type="gradleReference" />
     </platform>
     <platform name="ios">
         <config-file target="config.xml" parent="/*">

--- a/plugin/src/android/build.gradle
+++ b/plugin/src/android/build.gradle
@@ -21,10 +21,8 @@ repositories {
 dependencies {
     compileOnly("org.apache.cordova:framework:10.1.2")
     compileOnly("com.mparticle:android-core:6.0.0")
-    // Rokt facade and contracts moved out of android-core in 6.0.0.
+    // compileOnly matches cordova.gradle: Rokt kit is optional at runtime for integrators.
     compileOnly("com.mparticle:android-rokt-kit:6.0.0")
-    // roktEvents() collects the events() Flow via kotlinx-coroutines. The host app
-    // provides it at runtime (transitively via android-core/Rokt), so keep it compileOnly.
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 
     testImplementation("junit:junit:4.13.2")
@@ -32,6 +30,4 @@ dependencies {
     testImplementation("org.mockito:mockito-core:4.5.1")
     testImplementation("org.apache.cordova:framework:10.1.2")
     testImplementation("com.mparticle:android-core:6.0.0")
-    // Rokt kit stays compileOnly: pulling it into unit-test runtime pulls Jetpack Compose
-    // transitively (roktux), which AGP 7.1.3 cannot resolve for debugUnitTestRuntimeClasspath.
 }

--- a/plugin/src/android/build.gradle
+++ b/plugin/src/android/build.gradle
@@ -20,16 +20,17 @@ repositories {
 
 dependencies {
     compileOnly("org.apache.cordova:framework:10.1.2")
-    // Bounded range avoids resolving to 6.0.0-rc.1+ on Maven Central, which
-    // removed deprecated symbols this plugin relies on. See mparticle-android-sdk#710.
-    compileOnly("com.mparticle:android-core:[5.0,6.0)")
+    compileOnly("com.mparticle:android-core:6.0.0")
+    // Rokt facade and contracts moved out of android-core in 6.0.0.
+    compileOnly("com.mparticle:android-rokt-kit:6.0.0")
     // roktEvents() collects the events() Flow via kotlinx-coroutines. The host app
     // provides it at runtime (transitively via android-core/Rokt), so keep it compileOnly.
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20220320")
     testImplementation("org.mockito:mockito-core:4.5.1")
     testImplementation("org.apache.cordova:framework:10.1.2")
-    testImplementation("com.mparticle:android-core:[5.0,6.0)")
+    testImplementation("com.mparticle:android-core:6.0.0")
+    testImplementation("com.mparticle:android-rokt-kit:6.0.0")
 }

--- a/plugin/src/android/build.gradle
+++ b/plugin/src/android/build.gradle
@@ -32,5 +32,6 @@ dependencies {
     testImplementation("org.mockito:mockito-core:4.5.1")
     testImplementation("org.apache.cordova:framework:10.1.2")
     testImplementation("com.mparticle:android-core:6.0.0")
-    testImplementation("com.mparticle:android-rokt-kit:6.0.0")
+    // Rokt kit stays compileOnly: pulling it into unit-test runtime pulls Jetpack Compose
+    // transitively (roktux), which AGP 7.1.3 cannot resolve for debugUnitTestRuntimeClasspath.
 }

--- a/plugin/src/android/cordova.gradle
+++ b/plugin/src/android/cordova.gradle
@@ -1,0 +1,11 @@
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    // Compile against Rokt kit types without requiring it at runtime. Apps that use Rokt
+    // must install @mparticle/cordova-rokt-kit, which adds android-rokt-kit to the app.
+    compileOnly "com.mparticle:android-rokt-kit:6.0.0"
+    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
+}

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
@@ -4,7 +4,6 @@ import android.util.Log;
 
 import com.mparticle.MPEvent;
 import com.mparticle.MParticle;
-import com.mparticle.RoktEvent;
 import com.mparticle.commerce.CommerceEvent;
 import com.mparticle.commerce.Impression;
 import com.mparticle.commerce.Product;
@@ -15,8 +14,10 @@ import com.mparticle.consent.ConsentState;
 import com.mparticle.consent.GDPRConsent;
 import com.mparticle.identity.*;
 import com.mparticle.internal.Logger;
-import com.mparticle.rokt.RoktConfig;
-import com.mparticle.rokt.CacheConfig;
+import com.mparticle.kits.MParticleRoktKt;
+import com.rokt.roktsdk.CacheConfig;
+import com.rokt.roktsdk.RoktConfig;
+import com.rokt.roktsdk.RoktEvent;
 
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
@@ -443,34 +444,41 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
         }
     }
 
-    public void selectPlacements(final JSONArray args) throws JSONException {
-        final String identifier = args.getString(0);
-        final JSONObject attributesMap = args.getJSONObject(1);
-        final JSONObject configMap = args.getJSONObject(2);
-        
+    private com.mparticle.kits.Rokt rokt() {
+        return MParticleRoktKt.getRokt(MParticle.getInstance());
+    }
 
-        final Map<String, String> attributes = ConvertStringMap(attributesMap);
+    private RoktConfig buildRoktConfig(final JSONObject configMap) throws JSONException {
+        final RoktConfig.ColorMode colorMode = RoktConfig.ColorMode.valueOf(
+            configMap.getJSONObject("colorMode").getString("value")
+        );
 
-        final RoktConfig.ColorMode colorMode = RoktConfig.ColorMode.valueOf(configMap.getJSONObject("colorMode").getString("value"));
-        
         final JSONObject cacheConfigMap = configMap.getJSONObject("cacheConfig");
         final CacheConfig cacheConfig = new CacheConfig(
             cacheConfigMap.getLong("cacheDurationInSeconds"),
             ConvertStringMap(cacheConfigMap.getJSONObject("cacheAttributes"))
         );
-        
+
         final boolean edgeToEdgeDisplay = configMap.getBoolean("edgeToEdgeDisplay");
-        
-        final RoktConfig roktConfig = new RoktConfig.Builder()
+
+        return new RoktConfig.Builder()
             .colorMode(colorMode)
             .cacheConfig(cacheConfig)
             .edgeToEdgeDisplay(edgeToEdgeDisplay)
             .build();
+    }
 
-        MParticle.getInstance().Rokt().selectPlacements(
+    public void selectPlacements(final JSONArray args) throws JSONException {
+        final String identifier = args.getString(0);
+        final JSONObject attributesMap = args.getJSONObject(1);
+        final JSONObject configMap = args.getJSONObject(2);
+
+        final Map<String, String> attributes = ConvertStringMap(attributesMap);
+        final RoktConfig roktConfig = buildRoktConfig(configMap);
+
+        rokt().selectPlacements(
             identifier,
             attributes,
-            null,  // callbacks not used in Cordova
             null,  // embeddedViews not used in Cordova
             null,  // fontTypefaces not used in Cordova
             roktConfig
@@ -478,28 +486,36 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
     }
 
     public void selectShoppableAds(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        Logger.warning("selectShoppableAds is not yet supported on Android");
-        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
+        final String identifier = args.getString(0);
+        final JSONObject attributesMap = args.getJSONObject(1);
+        final JSONObject configMap = args.getJSONObject(2);
+
+        final Map<String, String> attributes = ConvertStringMap(attributesMap);
+        final RoktConfig roktConfig = buildRoktConfig(configMap);
+
+        rokt().selectShoppableAds(identifier, attributes, roktConfig);
+        callbackContext.success();
     }
 
     public void purchaseFinalized(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        // Shoppable Ads (selectShoppableAds) is not yet supported on Android, so there is no
-        // active shoppable session to finalize. No-op rather than calling the Rokt SDK without
-        // a session; matches the no-op pattern of handleURLCallback.
-        Logger.warning("purchaseFinalized is not yet supported on Android");
-        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
+        final String identifier = args.getString(0);
+        final String catalogItemId = args.getString(1);
+        final boolean success = args.getBoolean(2);
+
+        rokt().purchaseFinalized(identifier, catalogItemId, success);
+        callbackContext.success();
     }
 
     public void setSessionId(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
         final String sessionId = args.getString(0);
         if (sessionId != null && sessionId.length() > 0) {
-            MParticle.getInstance().Rokt().setSessionId(sessionId);
+            rokt().setSessionId(sessionId);
         }
         callbackContext.success();
     }
 
     public void getSessionId(final CallbackContext callbackContext) {
-        String sessionId = MParticle.getInstance().Rokt().getSessionId();
+        String sessionId = rokt().getSessionId();
         if (sessionId != null) {
             callbackContext.success(sessionId);
         } else {
@@ -524,7 +540,7 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
             CoroutineScopeKt.cancel(previous, (CancellationException) null);
         }
 
-        Flow<RoktEvent> events = MParticle.getInstance().Rokt().events(identifier);
+        Flow<RoktEvent> events = rokt().events(identifier);
 
         Function2<RoktEvent, Continuation<? super Unit>, Object> onEach =
             (event, continuation) -> {
@@ -565,38 +581,38 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
                 json.put("success", ((RoktEvent.InitComplete) event).getSuccess());
             } else if (event instanceof RoktEvent.PlacementReady) {
                 json.put("event", "PlacementReady");
-                json.put("placementId", ((RoktEvent.PlacementReady) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.PlacementReady) event).getIdentifier());
             } else if (event instanceof RoktEvent.PlacementInteractive) {
                 json.put("event", "PlacementInteractive");
-                json.put("placementId", ((RoktEvent.PlacementInteractive) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.PlacementInteractive) event).getIdentifier());
             } else if (event instanceof RoktEvent.PlacementClosed) {
                 json.put("event", "PlacementClosed");
-                json.put("placementId", ((RoktEvent.PlacementClosed) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.PlacementClosed) event).getIdentifier());
             } else if (event instanceof RoktEvent.PlacementCompleted) {
                 json.put("event", "PlacementCompleted");
-                json.put("placementId", ((RoktEvent.PlacementCompleted) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.PlacementCompleted) event).getIdentifier());
             } else if (event instanceof RoktEvent.PlacementFailure) {
                 json.put("event", "PlacementFailure");
-                String placementId = ((RoktEvent.PlacementFailure) event).getPlacementId();
+                String placementId = ((RoktEvent.PlacementFailure) event).getIdentifier();
                 json.put("placementId", placementId != null ? placementId : JSONObject.NULL);
             } else if (event instanceof RoktEvent.OfferEngagement) {
                 json.put("event", "OfferEngagement");
-                json.put("placementId", ((RoktEvent.OfferEngagement) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.OfferEngagement) event).getIdentifier());
             } else if (event instanceof RoktEvent.PositiveEngagement) {
                 json.put("event", "PositiveEngagement");
-                json.put("placementId", ((RoktEvent.PositiveEngagement) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.PositiveEngagement) event).getIdentifier());
             } else if (event instanceof RoktEvent.FirstPositiveEngagement) {
                 json.put("event", "FirstPositiveEngagement");
-                json.put("placementId", ((RoktEvent.FirstPositiveEngagement) event).getPlacementId());
+                json.put("placementId", ((RoktEvent.FirstPositiveEngagement) event).getIdentifier());
             } else if (event instanceof RoktEvent.OpenUrl) {
                 RoktEvent.OpenUrl openUrl = (RoktEvent.OpenUrl) event;
                 json.put("event", "OpenUrl");
-                json.put("placementId", openUrl.getPlacementId());
+                json.put("placementId", openUrl.getIdentifier());
                 json.put("url", openUrl.getUrl());
             } else if (event instanceof RoktEvent.CartItemInstantPurchase) {
                 RoktEvent.CartItemInstantPurchase purchase = (RoktEvent.CartItemInstantPurchase) event;
                 json.put("event", "CartItemInstantPurchase");
-                json.put("placementId", purchase.getPlacementId());
+                json.put("placementId", purchase.getIdentifier());
                 json.put("cartItemId", purchase.getCartItemId());
                 json.put("catalogItemId", purchase.getCatalogItemId());
                 json.put("currency", purchase.getCurrency());

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
@@ -14,19 +14,6 @@ import com.mparticle.consent.ConsentState;
 import com.mparticle.consent.GDPRConsent;
 import com.mparticle.identity.*;
 import com.mparticle.internal.Logger;
-import com.mparticle.kits.MParticleRoktKt;
-import com.rokt.roktsdk.CacheConfig;
-import com.rokt.roktsdk.RoktConfig;
-import com.rokt.roktsdk.RoktEvent;
-
-import kotlin.Unit;
-import kotlin.coroutines.Continuation;
-import kotlin.jvm.functions.Function2;
-import kotlinx.coroutines.CoroutineScope;
-import kotlinx.coroutines.CoroutineScopeKt;
-import kotlinx.coroutines.Dispatchers;
-import kotlinx.coroutines.flow.Flow;
-import kotlinx.coroutines.flow.FlowKt;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -44,7 +31,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 
 import static android.R.attr.type;
 
@@ -52,11 +38,8 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
 
     private final static String LOG_TAG = "MParticleCordovaPlugin";
 
-    // Active Rokt event subscriptions, keyed by placement identifier. Each holds the
-    // CoroutineScope collecting that identifier's event Flow so it can be torn down,
-    // preventing leaked scopes, duplicate subscriptions, and delivery through a stale
-    // callbackContext after the WebView is destroyed.
-    private final Map<String, CoroutineScope> roktEventScopes = new HashMap<>();
+    private RoktPluginDelegate roktDelegate;
+    private boolean roktDelegateInitialized;
 
     public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
         if (action.equals("logEvent")) {
@@ -112,32 +95,56 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
             removeCCPAConsentState(args);
             return true;
         } else if (action.equals("selectPlacements")) {
-            selectPlacements(args);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.selectPlacements(args, callbackContext));
         } else if (action.equals("selectShoppableAds")) {
-            selectShoppableAds(args, callbackContext);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.selectShoppableAds(args, callbackContext));
         } else if (action.equals("purchaseFinalized")) {
-            purchaseFinalized(args, callbackContext);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.purchaseFinalized(args, callbackContext));
         } else if (action.equals("setSessionId")) {
-            setSessionId(args, callbackContext);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.setSessionId(args, callbackContext));
         } else if (action.equals("getSessionId")) {
-            getSessionId(callbackContext);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.getSessionId(callbackContext));
         } else if (action.equals("handleURLCallback")) {
-            handleURLCallback(callbackContext);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.handleURLCallback(callbackContext));
         } else if (action.equals("roktEvents")) {
-            roktEvents(args, callbackContext);
-            return true;
+            return executeRoktAction(callbackContext, delegate -> delegate.roktEvents(args, callbackContext));
         } else {
             return false;
         }
 
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, args.getString(0)));
         return true;
+    }
+
+    private RoktPluginDelegate getRoktDelegate() {
+        if (!roktDelegateInitialized) {
+            roktDelegate = RoktKitAvailability.createDelegate();
+            roktDelegateInitialized = true;
+        }
+        return roktDelegate;
+    }
+
+    private interface RoktAction {
+        void run(RoktPluginDelegate delegate) throws JSONException;
+    }
+
+    private boolean executeRoktAction(CallbackContext callbackContext, RoktAction action) throws JSONException {
+        RoktPluginDelegate delegate = getRoktDelegate();
+        if (delegate == null) {
+            callbackContext.error(RoktKitAvailability.REQUIRED_MESSAGE);
+            return true;
+        }
+        action.run(delegate);
+        return true;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (roktDelegate != null) {
+            roktDelegate.onDestroy();
+            roktDelegate = null;
+        }
+        super.onDestroy();
     }
 
     public void logEvent(final JSONArray args) throws JSONException {
@@ -442,211 +449,6 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
 
             user.setConsentState(updatedState);
         }
-    }
-
-    private com.mparticle.kits.Rokt rokt() {
-        return MParticleRoktKt.getRokt(MParticle.getInstance());
-    }
-
-    private RoktConfig buildRoktConfig(final JSONObject configMap) throws JSONException {
-        if (configMap == null || configMap == JSONObject.NULL || configMap.length() == 0) {
-            return null;
-        }
-
-        final RoktConfig.Builder builder = new RoktConfig.Builder();
-        boolean hasConfig = false;
-
-        if (configMap.has("colorMode") && !configMap.isNull("colorMode")) {
-            final JSONObject colorModeObj = configMap.getJSONObject("colorMode");
-            if (colorModeObj.has("value") && !colorModeObj.isNull("value")) {
-                hasConfig = true;
-                builder.colorMode(RoktConfig.ColorMode.valueOf(colorModeObj.getString("value")));
-            }
-        }
-
-        if (configMap.has("cacheConfig") && !configMap.isNull("cacheConfig")) {
-            final JSONObject cacheConfigMap = configMap.getJSONObject("cacheConfig");
-            hasConfig = true;
-            final long cacheDuration = cacheConfigMap.has("cacheDurationInSeconds")
-                && !cacheConfigMap.isNull("cacheDurationInSeconds")
-                ? cacheConfigMap.getLong("cacheDurationInSeconds")
-                : 0L;
-            final JSONObject cacheAttributes = cacheConfigMap.has("cacheAttributes")
-                && !cacheConfigMap.isNull("cacheAttributes")
-                ? cacheConfigMap.getJSONObject("cacheAttributes")
-                : new JSONObject();
-            builder.cacheConfig(new CacheConfig(cacheDuration, ConvertStringMap(cacheAttributes)));
-        }
-
-        if (configMap.has("edgeToEdgeDisplay") && !configMap.isNull("edgeToEdgeDisplay")) {
-            hasConfig = true;
-            builder.edgeToEdgeDisplay(configMap.getBoolean("edgeToEdgeDisplay"));
-        }
-
-        return hasConfig ? builder.build() : null;
-    }
-
-    public void selectPlacements(final JSONArray args) throws JSONException {
-        final String identifier = args.getString(0);
-        final JSONObject attributesMap = args.getJSONObject(1);
-        final JSONObject configMap = args.isNull(2) ? null : args.getJSONObject(2);
-
-        final Map<String, String> attributes = ConvertStringMap(attributesMap);
-        final RoktConfig roktConfig = buildRoktConfig(configMap);
-
-        rokt().selectPlacements(
-            identifier,
-            attributes,
-            null,  // embeddedViews not used in Cordova
-            null,  // fontTypefaces not used in Cordova
-            roktConfig
-        );
-    }
-
-    public void selectShoppableAds(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        final String identifier = args.getString(0);
-        final JSONObject attributesMap = args.getJSONObject(1);
-        final JSONObject configMap = args.isNull(2) ? null : args.getJSONObject(2);
-
-        final Map<String, String> attributes = ConvertStringMap(attributesMap);
-        final RoktConfig roktConfig = buildRoktConfig(configMap);
-
-        rokt().selectShoppableAds(identifier, attributes, roktConfig);
-        callbackContext.success();
-    }
-
-    public void purchaseFinalized(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        final String identifier = args.getString(0);
-        final String catalogItemId = args.getString(1);
-        final boolean success = args.getBoolean(2);
-
-        rokt().purchaseFinalized(identifier, catalogItemId, success);
-        callbackContext.success();
-    }
-
-    public void setSessionId(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        final String sessionId = args.getString(0);
-        if (sessionId != null && sessionId.length() > 0) {
-            rokt().setSessionId(sessionId);
-        }
-        callbackContext.success();
-    }
-
-    public void getSessionId(final CallbackContext callbackContext) {
-        String sessionId = rokt().getSessionId();
-        if (sessionId != null) {
-            callbackContext.success(sessionId);
-        } else {
-            callbackContext.success();
-        }
-    }
-
-    public void handleURLCallback(final CallbackContext callbackContext) {
-        // The Rokt Android SDK does not yet expose a redirect-URL callback;
-        // matches the no-op behaviour of the sibling RN and Flutter wrappers.
-        Logger.warning("handleURLCallback is not yet supported on Android");
-        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
-    }
-
-    public void roktEvents(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        final String identifier = args.getString(0);
-
-        // Tear down any prior subscription for this identifier so repeated calls don't
-        // stack duplicate collectors all delivering through different callbacks.
-        CoroutineScope previous = roktEventScopes.remove(identifier);
-        if (previous != null) {
-            CoroutineScopeKt.cancel(previous, (CancellationException) null);
-        }
-
-        Flow<RoktEvent> events = rokt().events(identifier);
-
-        Function2<RoktEvent, Continuation<? super Unit>, Object> onEach =
-            (event, continuation) -> {
-                JSONObject json = jsonFromRoktEvent(event);
-                if (json != null) {
-                    PluginResult result = new PluginResult(PluginResult.Status.OK, json);
-                    result.setKeepCallback(true);
-                    callbackContext.sendPluginResult(result);
-                }
-                return Unit.INSTANCE;
-            };
-
-        CoroutineScope scope = CoroutineScopeKt.CoroutineScope(Dispatchers.getDefault());
-        FlowKt.launchIn(FlowKt.onEach(events, onEach), scope);
-        roktEventScopes.put(identifier, scope);
-    }
-
-    @Override
-    public void onDestroy() {
-        // Cancel every active Rokt event subscription so collectors stop running and
-        // never deliver results through a callbackContext tied to a dead WebView.
-        for (CoroutineScope scope : roktEventScopes.values()) {
-            CoroutineScopeKt.cancel(scope, (CancellationException) null);
-        }
-        roktEventScopes.clear();
-        super.onDestroy();
-    }
-
-    private static JSONObject jsonFromRoktEvent(RoktEvent event) {
-        JSONObject json = new JSONObject();
-        try {
-            if (event instanceof RoktEvent.ShowLoadingIndicator) {
-                json.put("event", "ShowLoadingIndicator");
-            } else if (event instanceof RoktEvent.HideLoadingIndicator) {
-                json.put("event", "HideLoadingIndicator");
-            } else if (event instanceof RoktEvent.InitComplete) {
-                json.put("event", "InitComplete");
-                json.put("success", ((RoktEvent.InitComplete) event).getSuccess());
-            } else if (event instanceof RoktEvent.PlacementReady) {
-                json.put("event", "PlacementReady");
-                json.put("placementId", ((RoktEvent.PlacementReady) event).getIdentifier());
-            } else if (event instanceof RoktEvent.PlacementInteractive) {
-                json.put("event", "PlacementInteractive");
-                json.put("placementId", ((RoktEvent.PlacementInteractive) event).getIdentifier());
-            } else if (event instanceof RoktEvent.PlacementClosed) {
-                json.put("event", "PlacementClosed");
-                json.put("placementId", ((RoktEvent.PlacementClosed) event).getIdentifier());
-            } else if (event instanceof RoktEvent.PlacementCompleted) {
-                json.put("event", "PlacementCompleted");
-                json.put("placementId", ((RoktEvent.PlacementCompleted) event).getIdentifier());
-            } else if (event instanceof RoktEvent.PlacementFailure) {
-                json.put("event", "PlacementFailure");
-                String placementId = ((RoktEvent.PlacementFailure) event).getIdentifier();
-                json.put("placementId", placementId != null ? placementId : JSONObject.NULL);
-            } else if (event instanceof RoktEvent.OfferEngagement) {
-                json.put("event", "OfferEngagement");
-                json.put("placementId", ((RoktEvent.OfferEngagement) event).getIdentifier());
-            } else if (event instanceof RoktEvent.PositiveEngagement) {
-                json.put("event", "PositiveEngagement");
-                json.put("placementId", ((RoktEvent.PositiveEngagement) event).getIdentifier());
-            } else if (event instanceof RoktEvent.FirstPositiveEngagement) {
-                json.put("event", "FirstPositiveEngagement");
-                json.put("placementId", ((RoktEvent.FirstPositiveEngagement) event).getIdentifier());
-            } else if (event instanceof RoktEvent.OpenUrl) {
-                RoktEvent.OpenUrl openUrl = (RoktEvent.OpenUrl) event;
-                json.put("event", "OpenUrl");
-                json.put("placementId", openUrl.getIdentifier());
-                json.put("url", openUrl.getUrl());
-            } else if (event instanceof RoktEvent.CartItemInstantPurchase) {
-                RoktEvent.CartItemInstantPurchase purchase = (RoktEvent.CartItemInstantPurchase) event;
-                json.put("event", "CartItemInstantPurchase");
-                json.put("placementId", purchase.getIdentifier());
-                json.put("cartItemId", purchase.getCartItemId());
-                json.put("catalogItemId", purchase.getCatalogItemId());
-                json.put("currency", purchase.getCurrency());
-                json.put("description", purchase.getDescription());
-                json.put("linkedProductId", purchase.getLinkedProductId());
-                json.put("totalPrice", purchase.getTotalPrice());
-                json.put("quantity", purchase.getQuantity());
-                json.put("unitPrice", purchase.getUnitPrice());
-            } else {
-                json.put("event", event.getClass().getSimpleName());
-            }
-        } catch (JSONException e) {
-            Logger.warning(e, "Failed to serialize RoktEvent");
-            return null;
-        }
-        return json;
     }
 
     private static IdentityApiRequest ConvertIdentityAPIRequest(JSONObject map) throws JSONException {

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
@@ -449,29 +449,47 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
     }
 
     private RoktConfig buildRoktConfig(final JSONObject configMap) throws JSONException {
-        final RoktConfig.ColorMode colorMode = RoktConfig.ColorMode.valueOf(
-            configMap.getJSONObject("colorMode").getString("value")
-        );
+        if (configMap == null || configMap == JSONObject.NULL || configMap.length() == 0) {
+            return null;
+        }
 
-        final JSONObject cacheConfigMap = configMap.getJSONObject("cacheConfig");
-        final CacheConfig cacheConfig = new CacheConfig(
-            cacheConfigMap.getLong("cacheDurationInSeconds"),
-            ConvertStringMap(cacheConfigMap.getJSONObject("cacheAttributes"))
-        );
+        final RoktConfig.Builder builder = new RoktConfig.Builder();
+        boolean hasConfig = false;
 
-        final boolean edgeToEdgeDisplay = configMap.getBoolean("edgeToEdgeDisplay");
+        if (configMap.has("colorMode") && !configMap.isNull("colorMode")) {
+            final JSONObject colorModeObj = configMap.getJSONObject("colorMode");
+            if (colorModeObj.has("value") && !colorModeObj.isNull("value")) {
+                hasConfig = true;
+                builder.colorMode(RoktConfig.ColorMode.valueOf(colorModeObj.getString("value")));
+            }
+        }
 
-        return new RoktConfig.Builder()
-            .colorMode(colorMode)
-            .cacheConfig(cacheConfig)
-            .edgeToEdgeDisplay(edgeToEdgeDisplay)
-            .build();
+        if (configMap.has("cacheConfig") && !configMap.isNull("cacheConfig")) {
+            final JSONObject cacheConfigMap = configMap.getJSONObject("cacheConfig");
+            hasConfig = true;
+            final long cacheDuration = cacheConfigMap.has("cacheDurationInSeconds")
+                && !cacheConfigMap.isNull("cacheDurationInSeconds")
+                ? cacheConfigMap.getLong("cacheDurationInSeconds")
+                : 0L;
+            final JSONObject cacheAttributes = cacheConfigMap.has("cacheAttributes")
+                && !cacheConfigMap.isNull("cacheAttributes")
+                ? cacheConfigMap.getJSONObject("cacheAttributes")
+                : new JSONObject();
+            builder.cacheConfig(new CacheConfig(cacheDuration, ConvertStringMap(cacheAttributes)));
+        }
+
+        if (configMap.has("edgeToEdgeDisplay") && !configMap.isNull("edgeToEdgeDisplay")) {
+            hasConfig = true;
+            builder.edgeToEdgeDisplay(configMap.getBoolean("edgeToEdgeDisplay"));
+        }
+
+        return hasConfig ? builder.build() : null;
     }
 
     public void selectPlacements(final JSONArray args) throws JSONException {
         final String identifier = args.getString(0);
         final JSONObject attributesMap = args.getJSONObject(1);
-        final JSONObject configMap = args.getJSONObject(2);
+        final JSONObject configMap = args.isNull(2) ? null : args.getJSONObject(2);
 
         final Map<String, String> attributes = ConvertStringMap(attributesMap);
         final RoktConfig roktConfig = buildRoktConfig(configMap);
@@ -488,7 +506,7 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
     public void selectShoppableAds(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
         final String identifier = args.getString(0);
         final JSONObject attributesMap = args.getJSONObject(1);
-        final JSONObject configMap = args.getJSONObject(2);
+        final JSONObject configMap = args.isNull(2) ? null : args.getJSONObject(2);
 
         final Map<String, String> attributes = ConvertStringMap(attributesMap);
         final RoktConfig roktConfig = buildRoktConfig(configMap);

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/MParticleCordovaPlugin.java
@@ -105,7 +105,9 @@ public class MParticleCordovaPlugin extends CordovaPlugin {
         } else if (action.equals("getSessionId")) {
             return executeRoktAction(callbackContext, delegate -> delegate.getSessionId(callbackContext));
         } else if (action.equals("handleURLCallback")) {
-            return executeRoktAction(callbackContext, delegate -> delegate.handleURLCallback(callbackContext));
+            // iOS-only; Android resolves to false without requiring the Rokt kit.
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
+            return true;
         } else if (action.equals("roktEvents")) {
             return executeRoktAction(callbackContext, delegate -> delegate.roktEvents(args, callbackContext));
         } else {

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/RoktBridge.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/RoktBridge.java
@@ -1,0 +1,248 @@
+package com.mparticle.cordova;
+
+import com.mparticle.MParticle;
+import com.mparticle.internal.Logger;
+import com.mparticle.kits.MParticleRoktKt;
+import com.rokt.roktsdk.CacheConfig;
+import com.rokt.roktsdk.RoktConfig;
+import com.rokt.roktsdk.RoktEvent;
+
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import kotlin.jvm.functions.Function2;
+import kotlinx.coroutines.CoroutineScope;
+import kotlinx.coroutines.CoroutineScopeKt;
+import kotlinx.coroutines.Dispatchers;
+import kotlinx.coroutines.flow.Flow;
+import kotlinx.coroutines.flow.FlowKt;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+
+final class RoktBridge implements RoktPluginDelegate {
+    private final Map<String, CoroutineScope> roktEventScopes = new HashMap<>();
+
+    private com.mparticle.kits.Rokt rokt() {
+        return MParticleRoktKt.getRokt(MParticle.getInstance());
+    }
+
+    @Override
+    public void selectPlacements(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        final String identifier = args.getString(0);
+        final JSONObject attributesMap = args.getJSONObject(1);
+        final JSONObject configMap = args.isNull(2) ? null : args.getJSONObject(2);
+
+        final Map<String, String> attributes = convertStringMap(attributesMap);
+        final RoktConfig roktConfig = buildRoktConfig(configMap);
+
+        rokt().selectPlacements(
+            identifier,
+            attributes,
+            null,
+            null,
+            roktConfig
+        );
+        callbackContext.success();
+    }
+
+    @Override
+    public void selectShoppableAds(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        final String identifier = args.getString(0);
+        final JSONObject attributesMap = args.getJSONObject(1);
+        final JSONObject configMap = args.isNull(2) ? null : args.getJSONObject(2);
+
+        final Map<String, String> attributes = convertStringMap(attributesMap);
+        final RoktConfig roktConfig = buildRoktConfig(configMap);
+
+        rokt().selectShoppableAds(identifier, attributes, roktConfig);
+        callbackContext.success();
+    }
+
+    @Override
+    public void purchaseFinalized(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        final String identifier = args.getString(0);
+        final String catalogItemId = args.getString(1);
+        final boolean success = args.getBoolean(2);
+
+        rokt().purchaseFinalized(identifier, catalogItemId, success);
+        callbackContext.success();
+    }
+
+    @Override
+    public void setSessionId(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        final String sessionId = args.getString(0);
+        if (sessionId != null && sessionId.length() > 0) {
+            rokt().setSessionId(sessionId);
+        }
+        callbackContext.success();
+    }
+
+    @Override
+    public void getSessionId(final CallbackContext callbackContext) {
+        String sessionId = rokt().getSessionId();
+        if (sessionId != null) {
+            callbackContext.success(sessionId);
+        } else {
+            callbackContext.success();
+        }
+    }
+
+    @Override
+    public void handleURLCallback(final CallbackContext callbackContext) {
+        Logger.warning("handleURLCallback is not yet supported on Android");
+        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
+    }
+
+    @Override
+    public void roktEvents(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        final String identifier = args.getString(0);
+
+        CoroutineScope previous = roktEventScopes.remove(identifier);
+        if (previous != null) {
+            CoroutineScopeKt.cancel(previous, (CancellationException) null);
+        }
+
+        Flow<RoktEvent> events = rokt().events(identifier);
+
+        Function2<RoktEvent, Continuation<? super Unit>, Object> onEach =
+            (event, continuation) -> {
+                JSONObject json = jsonFromRoktEvent(event);
+                if (json != null) {
+                    PluginResult result = new PluginResult(PluginResult.Status.OK, json);
+                    result.setKeepCallback(true);
+                    callbackContext.sendPluginResult(result);
+                }
+                return Unit.INSTANCE;
+            };
+
+        CoroutineScope scope = CoroutineScopeKt.CoroutineScope(Dispatchers.getDefault());
+        FlowKt.launchIn(FlowKt.onEach(events, onEach), scope);
+        roktEventScopes.put(identifier, scope);
+    }
+
+    @Override
+    public void onDestroy() {
+        for (CoroutineScope scope : roktEventScopes.values()) {
+            CoroutineScopeKt.cancel(scope, (CancellationException) null);
+        }
+        roktEventScopes.clear();
+    }
+
+    private static RoktConfig buildRoktConfig(final JSONObject configMap) throws JSONException {
+        if (configMap == null || configMap == JSONObject.NULL || configMap.length() == 0) {
+            return null;
+        }
+
+        final RoktConfig.Builder builder = new RoktConfig.Builder();
+        boolean hasConfig = false;
+
+        if (configMap.has("colorMode") && !configMap.isNull("colorMode")) {
+            final JSONObject colorModeObj = configMap.getJSONObject("colorMode");
+            if (colorModeObj.has("value") && !colorModeObj.isNull("value")) {
+                hasConfig = true;
+                builder.colorMode(RoktConfig.ColorMode.valueOf(colorModeObj.getString("value")));
+            }
+        }
+
+        if (configMap.has("cacheConfig") && !configMap.isNull("cacheConfig")) {
+            final JSONObject cacheConfigMap = configMap.getJSONObject("cacheConfig");
+            hasConfig = true;
+            final long cacheDuration = cacheConfigMap.has("cacheDurationInSeconds")
+                && !cacheConfigMap.isNull("cacheDurationInSeconds")
+                ? cacheConfigMap.getLong("cacheDurationInSeconds")
+                : 0L;
+            final JSONObject cacheAttributes = cacheConfigMap.has("cacheAttributes")
+                && !cacheConfigMap.isNull("cacheAttributes")
+                ? cacheConfigMap.getJSONObject("cacheAttributes")
+                : new JSONObject();
+            builder.cacheConfig(new CacheConfig(cacheDuration, convertStringMap(cacheAttributes)));
+        }
+
+        if (configMap.has("edgeToEdgeDisplay") && !configMap.isNull("edgeToEdgeDisplay")) {
+            hasConfig = true;
+            builder.edgeToEdgeDisplay(configMap.getBoolean("edgeToEdgeDisplay"));
+        }
+
+        return hasConfig ? builder.build() : null;
+    }
+
+    private static JSONObject jsonFromRoktEvent(RoktEvent event) {
+        JSONObject json = new JSONObject();
+        try {
+            if (event instanceof RoktEvent.ShowLoadingIndicator) {
+                json.put("event", "ShowLoadingIndicator");
+            } else if (event instanceof RoktEvent.HideLoadingIndicator) {
+                json.put("event", "HideLoadingIndicator");
+            } else if (event instanceof RoktEvent.InitComplete) {
+                json.put("event", "InitComplete");
+                json.put("success", ((RoktEvent.InitComplete) event).getSuccess());
+            } else if (event instanceof RoktEvent.PlacementReady) {
+                json.put("event", "PlacementReady");
+                json.put("placementId", ((RoktEvent.PlacementReady) event).getIdentifier());
+            } else if (event instanceof RoktEvent.PlacementInteractive) {
+                json.put("event", "PlacementInteractive");
+                json.put("placementId", ((RoktEvent.PlacementInteractive) event).getIdentifier());
+            } else if (event instanceof RoktEvent.PlacementClosed) {
+                json.put("event", "PlacementClosed");
+                json.put("placementId", ((RoktEvent.PlacementClosed) event).getIdentifier());
+            } else if (event instanceof RoktEvent.PlacementCompleted) {
+                json.put("event", "PlacementCompleted");
+                json.put("placementId", ((RoktEvent.PlacementCompleted) event).getIdentifier());
+            } else if (event instanceof RoktEvent.PlacementFailure) {
+                json.put("event", "PlacementFailure");
+                String placementId = ((RoktEvent.PlacementFailure) event).getIdentifier();
+                json.put("placementId", placementId != null ? placementId : JSONObject.NULL);
+            } else if (event instanceof RoktEvent.OfferEngagement) {
+                json.put("event", "OfferEngagement");
+                json.put("placementId", ((RoktEvent.OfferEngagement) event).getIdentifier());
+            } else if (event instanceof RoktEvent.PositiveEngagement) {
+                json.put("event", "PositiveEngagement");
+                json.put("placementId", ((RoktEvent.PositiveEngagement) event).getIdentifier());
+            } else if (event instanceof RoktEvent.FirstPositiveEngagement) {
+                json.put("event", "FirstPositiveEngagement");
+                json.put("placementId", ((RoktEvent.FirstPositiveEngagement) event).getIdentifier());
+            } else if (event instanceof RoktEvent.OpenUrl) {
+                RoktEvent.OpenUrl openUrl = (RoktEvent.OpenUrl) event;
+                json.put("event", "OpenUrl");
+                json.put("placementId", openUrl.getIdentifier());
+                json.put("url", openUrl.getUrl());
+            } else if (event instanceof RoktEvent.CartItemInstantPurchase) {
+                RoktEvent.CartItemInstantPurchase purchase = (RoktEvent.CartItemInstantPurchase) event;
+                json.put("event", "CartItemInstantPurchase");
+                json.put("placementId", purchase.getIdentifier());
+                json.put("cartItemId", purchase.getCartItemId());
+                json.put("catalogItemId", purchase.getCatalogItemId());
+                json.put("currency", purchase.getCurrency());
+                json.put("description", purchase.getDescription());
+                json.put("linkedProductId", purchase.getLinkedProductId());
+                json.put("totalPrice", purchase.getTotalPrice());
+                json.put("quantity", purchase.getQuantity());
+                json.put("unitPrice", purchase.getUnitPrice());
+            } else {
+                json.put("event", event.getClass().getSimpleName());
+            }
+        } catch (JSONException e) {
+            Logger.warning(e, "Failed to serialize RoktEvent");
+            return null;
+        }
+        return json;
+    }
+
+    private static Map<String, String> convertStringMap(final JSONObject jsonObject) throws JSONException {
+        Map<String, String> stringMap = new HashMap<>();
+        Iterator<String> keys = jsonObject.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            stringMap.put(key, jsonObject.getString(key));
+        }
+        return stringMap;
+    }
+}

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/RoktBridge.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/RoktBridge.java
@@ -96,12 +96,6 @@ final class RoktBridge implements RoktPluginDelegate {
     }
 
     @Override
-    public void handleURLCallback(final CallbackContext callbackContext) {
-        Logger.warning("handleURLCallback is not yet supported on Android");
-        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
-    }
-
-    @Override
     public void roktEvents(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
         final String identifier = args.getString(0);
 

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/RoktKitAvailability.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/RoktKitAvailability.java
@@ -1,0 +1,29 @@
+package com.mparticle.cordova;
+
+final class RoktKitAvailability {
+    static final String REQUIRED_MESSAGE =
+        "Rokt is unavailable. Install @mparticle/cordova-rokt-kit to enable Rokt APIs.";
+
+    private static final String ROKT_EMBEDDED_VIEW_CLASS = "com.mparticle.kits.RoktEmbeddedView";
+
+    private RoktKitAvailability() {
+    }
+
+    static boolean isAvailable() {
+        try {
+            Class.forName(ROKT_EMBEDDED_VIEW_CLASS);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        } catch (LinkageError e) {
+            return false;
+        }
+    }
+
+    static RoktPluginDelegate createDelegate() {
+        if (!isAvailable()) {
+            return null;
+        }
+        return new RoktBridge();
+    }
+}

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/RoktPluginDelegate.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/RoktPluginDelegate.java
@@ -15,8 +15,6 @@ interface RoktPluginDelegate {
 
     void getSessionId(CallbackContext callbackContext);
 
-    void handleURLCallback(CallbackContext callbackContext);
-
     void roktEvents(JSONArray args, CallbackContext callbackContext) throws JSONException;
 
     void onDestroy();

--- a/plugin/src/android/src/main/java/com/mparticle/cordova/RoktPluginDelegate.java
+++ b/plugin/src/android/src/main/java/com/mparticle/cordova/RoktPluginDelegate.java
@@ -1,0 +1,23 @@
+package com.mparticle.cordova;
+
+import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+interface RoktPluginDelegate {
+    void selectPlacements(JSONArray args, CallbackContext callbackContext) throws JSONException;
+
+    void selectShoppableAds(JSONArray args, CallbackContext callbackContext) throws JSONException;
+
+    void purchaseFinalized(JSONArray args, CallbackContext callbackContext) throws JSONException;
+
+    void setSessionId(JSONArray args, CallbackContext callbackContext) throws JSONException;
+
+    void getSessionId(CallbackContext callbackContext);
+
+    void handleURLCallback(CallbackContext callbackContext);
+
+    void roktEvents(JSONArray args, CallbackContext callbackContext) throws JSONException;
+
+    void onDestroy();
+}

--- a/plugin/www/mparticle.js
+++ b/plugin/www/mparticle.js
@@ -580,8 +580,7 @@ var mparticle = {
      * Cordova bridge accepts a string URL, marshals it to NSURL, and asks
      * the Rokt payment extension(s) to claim it.
      *
-     * iOS only; the Rokt Android SDK doesn't yet expose this hook, so the
-     * Android bridge logs a warning and resolves to `false`.
+     * iOS only; the Android bridge resolves to `false`.
      *
      * The completion callback receives a boolean indicating whether a
      * registered payment extension handled the URL.


### PR DESCRIPTION
## Background
- The Cordova plugin was pinned to older native mParticle SDKs (android-core:5.79.1, mParticle-Apple-SDK ~> 9.2) and deliberately capped Android resolution below 6.0.0 to avoid breaking changes in pre-release builds.
- mParticle has since shipped stable Android SDK 6.0.0 and Apple SDK v9.3.1, which introduce meaningful Rokt and consent updates. Android 6.0.0 in particular moves Rokt out of android-core and into android-rokt-kit / com.rokt.roktsdk, which would break the existing Android bridge without migration.
- Shoppable Ads APIs (selectShoppableAds, purchaseFinalized) were previously no-ops on Android even though the underlying SDK now supports them.
- Android 6.0.0 also exposed an architectural issue: the core plugin bundled Rokt bridge code but did not declare android-rokt-kit as a Cordova dependency, so apps installing only @mparticle/cordova-sdk could fail to compile on Android.

## What Has Changed
- Bumped native dependency pins to Android SDK 6.0.0 (com.mparticle:android-core, com.mparticle:android-rokt-kit) and iOS SDK 9.3.x (mParticle-Apple-SDK ~> 9.3, mParticle-Rokt ~> 9.3) in plugin/plugin.xml and Kits/Rokt/plugin.xml.
- Migrated the Android Rokt bridge for SDK 6.0.0:
- Access Rokt via MParticleRoktKt.getRokt() instead of MParticle.getInstance().Rokt()
- Updated types to com.rokt.roktsdk.RoktEvent, RoktConfig, and CacheConfig
- Updated event serialization to use getIdentifier() instead of removed getPlacementId()
- Added android-rokt-kit:6.0.0 as a compile dependency in plugin/src/android/build.gradle
- Enabled Android Shoppable Ads by wiring selectShoppableAds and purchaseFinalized to the native SDK (previously logged warnings and no-oped).
- Updated release documentation:
- CHANGELOG.md — new Android Shoppable Ads support, and known gaps (device-level consent, Android handleURLCallback, iOS-only payment extension kit)
- README.md — native SDK version table, updated iOS pod requirement, revised Shoppable Ads guidance, updated kit install specs
- Kits/Rokt/README.md — corrected stale dependency version references
- Refactored Android Rokt behind RoktKitAvailability / RoktBridge / RoktPluginDelegate, matching the optional-kit pattern used in 
[mparticle-flutter-sdk#76](https://github.com/mParticle/mparticle-flutter-sdk/pull/76).
Core plugin compiles against android-rokt-kit via compileOnly (wired through plugin/src/android/cordova.gradle + gradleReference in plugin.xml), not as a runtime dependency.
Apps without @mparticle/cordova-rokt-kit build successfully; Rokt JS calls return a clear error until the kit is installed.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
